### PR TITLE
Toggleable E2E audio stability patches

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,27 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Verify whitespace formatting
+        run: dotnet format whitespace --verify-no-changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
-name: CI
+name: Release CI
 
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -35,7 +34,6 @@ jobs:
         run: dotnet format whitespace --verify-no-changes
 
   build:
-    if: github.event_name != 'pull_request'
     runs-on: windows-latest
     needs: formatting
     steps:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>
@@ -70,7 +70,8 @@
       <HintPath Condition="Exists('$(ResoniteManagedPath)FrooxEngine.dll')"
         >$(ResoniteManagedPath)FrooxEngine.dll</HintPath
       >
-      <HintPath Condition="!Exists('$(ResoniteManagedPath)FrooxEngine.dll') and Exists('$(ResonitePath)FrooxEngine.dll')"
+      <HintPath
+        Condition="!Exists('$(ResoniteManagedPath)FrooxEngine.dll') and Exists('$(ResonitePath)FrooxEngine.dll')"
         >$(ResonitePath)FrooxEngine.dll</HintPath
       >
       <Private>false</Private>
@@ -79,7 +80,8 @@
       <HintPath Condition="Exists('$(ResoniteManagedPath)Elements.Core.dll')"
         >$(ResoniteManagedPath)Elements.Core.dll</HintPath
       >
-      <HintPath Condition="!Exists('$(ResoniteManagedPath)Elements.Core.dll') and Exists('$(ResonitePath)Elements.Core.dll')"
+      <HintPath
+        Condition="!Exists('$(ResoniteManagedPath)Elements.Core.dll') and Exists('$(ResonitePath)Elements.Core.dll')"
         >$(ResonitePath)Elements.Core.dll</HintPath
       >
       <Private>false</Private>
@@ -88,7 +90,8 @@
       <HintPath Condition="Exists('$(ResoniteManagedPath)Elements.Assets.dll')"
         >$(ResoniteManagedPath)Elements.Assets.dll</HintPath
       >
-      <HintPath Condition="!Exists('$(ResoniteManagedPath)Elements.Assets.dll') and Exists('$(ResonitePath)Elements.Assets.dll')"
+      <HintPath
+        Condition="!Exists('$(ResoniteManagedPath)Elements.Assets.dll') and Exists('$(ResonitePath)Elements.Assets.dll')"
         >$(ResonitePath)Elements.Assets.dll</HintPath
       >
       <Private>false</Private>
@@ -97,8 +100,19 @@
       <HintPath Condition="Exists('$(ResoniteManagedPath)POpusCodec.dll')"
         >$(ResoniteManagedPath)POpusCodec.dll</HintPath
       >
-      <HintPath Condition="!Exists('$(ResoniteManagedPath)POpusCodec.dll') and Exists('$(ResonitePath)POpusCodec.dll')"
+      <HintPath
+        Condition="!Exists('$(ResoniteManagedPath)POpusCodec.dll') and Exists('$(ResonitePath)POpusCodec.dll')"
         >$(ResonitePath)POpusCodec.dll</HintPath
+      >
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Awwdio">
+      <HintPath Condition="Exists('$(ResoniteManagedPath)Awwdio.dll')"
+        >$(ResoniteManagedPath)Awwdio.dll</HintPath
+      >
+      <HintPath
+        Condition="!Exists('$(ResoniteManagedPath)Awwdio.dll') and Exists('$(ResonitePath)Awwdio.dll')"
+        >$(ResonitePath)Awwdio.dll</HintPath
       >
       <Private>false</Private>
     </Reference>

--- a/TurboAudioStream.PrePatcher/TurboAudioStream.PrePatcher.csproj
+++ b/TurboAudioStream.PrePatcher/TurboAudioStream.PrePatcher.csproj
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <NoWarn>NU1603</NoWarn>
-    </PropertyGroup>
-    <ItemGroup>
-        <!-- MonkeyLoader GamePack for Resonite (provides Shim assemblies) -->
-        <PackageReference Include="MonkeyLoader.GamePacks.Resonite" />
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NoWarn>NU1603</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- MonkeyLoader GamePack for Resonite (provides Shim assemblies) -->
+    <PackageReference Include="MonkeyLoader.GamePacks.Resonite" />
 
-        <!-- Direct references to actual Resonite assemblies for type resolution -->
-        <Reference Include="FrooxEngine">
-            <HintPath>$(ResoniteManagedPath)FrooxEngine.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="Elements.Core">
-            <HintPath>$(ResoniteManagedPath)Elements.Core.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="Elements.Assets">
-            <HintPath>$(ResoniteManagedPath)Elements.Assets.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="POpusCodec">
-            <HintPath>$(ResoniteManagedPath)POpusCodec.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
+    <!-- Direct references to actual Resonite assemblies for type resolution -->
+    <Reference Include="FrooxEngine">
+      <HintPath>$(ResoniteManagedPath)FrooxEngine.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Elements.Core">
+      <HintPath>$(ResoniteManagedPath)Elements.Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Elements.Assets">
+      <HintPath>$(ResoniteManagedPath)Elements.Assets.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="POpusCodec">
+      <HintPath>$(ResoniteManagedPath)POpusCodec.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
 
-        <!-- Update pattern for any other Resonite assemblies -->
-        <Reference Update="Resonite.*">
-            <HintPath>$(ResoniteManagedPath)%(Filename).dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-    </ItemGroup>
+    <!-- Update pattern for any other Resonite assemblies -->
+    <Reference Update="Resonite.*">
+      <HintPath>$(ResoniteManagedPath)%(Filename).dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/TurboAudioStream/AudioBindingRepairHelper.cs
+++ b/TurboAudioStream/AudioBindingRepairHelper.cs
@@ -25,7 +25,10 @@ internal static class AudioBindingRepairHelper
             repaired = true;
         }
 
-        if (source is OpusStream<StereoSample> opusStream && audioStreamInterface.Bitrate.Target is null)
+        if (
+            source is OpusStream<StereoSample> opusStream
+            && audioStreamInterface.Bitrate.Target is null
+        )
         {
             audioStreamInterface.Bitrate.Target = opusStream.BitRate;
             repaired = true;

--- a/TurboAudioStream/AudioPatchManager.cs
+++ b/TurboAudioStream/AudioPatchManager.cs
@@ -62,14 +62,14 @@ internal static class AudioPatchManager
             {
                 foreach (Type patchType in registration.PatchTypes)
                 {
-                    registration.Harmony.CreateClassProcessor(patchType).Patch();
+                    _ = registration.Harmony.CreateClassProcessor(patchType).Patch();
                 }
 
                 registration.IsPatched = true;
             }
             else if (!shouldBeEnabled && registration.IsPatched)
             {
-                registration.Harmony.UnpatchSelf();
+                registration.Harmony.UnpatchAll(registration.Harmony.Id);
                 registration.IsPatched = false;
             }
         }
@@ -79,7 +79,7 @@ internal static class AudioPatchManager
     {
         foreach ((_, PatchRegistration registration) in Registrations)
         {
-            registration.Harmony.UnpatchSelf();
+            registration.Harmony.UnpatchAll(registration.Harmony.Id);
             registration.IsPatched = false;
         }
     }

--- a/TurboAudioStream/AudioPatchPredicates.cs
+++ b/TurboAudioStream/AudioPatchPredicates.cs
@@ -20,6 +20,6 @@ internal static class AudioPatchPredicates
     )
     {
         opusStream = stream as OpusStream<StereoSample>;
-        return opusStream?.User?.IsLocalUser != true;
+        return opusStream is not null && opusStream.User?.IsLocalUser != true;
     }
 }

--- a/TurboAudioStream/AudioPatchPredicates.cs
+++ b/TurboAudioStream/AudioPatchPredicates.cs
@@ -5,7 +5,10 @@ namespace TurboAudioStream;
 
 internal static class AudioPatchPredicates
 {
-    public static bool IsLocalSenderOpusStream(IAudioStream source, out OpusStream<StereoSample>? stream)
+    public static bool IsLocalSenderOpusStream(
+        IAudioStream source,
+        out OpusStream<StereoSample>? stream
+    )
     {
         stream = source as OpusStream<StereoSample>;
         return stream?.User?.IsLocalUser == true;

--- a/TurboAudioStream/PatchTriggerLogger.cs
+++ b/TurboAudioStream/PatchTriggerLogger.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using Elements.Core;
 using FrooxEngine;
 using ResoniteModLoader;
 
@@ -34,10 +33,7 @@ internal static class PatchTriggerLogger
             Math.Max(0f, TurboAudioStreamConfig.PatchLogCooldownSeconds)
         );
 
-        if (
-            LastLogTimes.TryGetValue(key, out DateTime lastLogTime)
-            && now - lastLogTime < cooldown
-        )
+        if (LastLogTimes.TryGetValue(key, out DateTime lastLogTime) && now - lastLogTime < cooldown)
         {
             return;
         }

--- a/TurboAudioStream/Patches/AudioStreamInterface_BindRepair_Patch.cs
+++ b/TurboAudioStream/Patches/AudioStreamInterface_BindRepair_Patch.cs
@@ -1,4 +1,3 @@
-using Elements.Assets;
 using FrooxEngine;
 using HarmonyLib;
 
@@ -20,17 +19,23 @@ internal static class AudioStreamInterface_BindRepair_Patch
             return;
         }
 
-        if (!AudioBindingRepairHelper.TryRepair(__instance, source, out AudioStreamController? controller))
+        if (
+            !AudioBindingRepairHelper.TryRepair(
+                __instance,
+                source,
+                out AudioStreamController? controller
+            )
+        )
         {
             return;
         }
 
-        User? user = (source as IAudioStream)?.User;
+        User? user = source.User;
         PatchTriggerLogger.Log(
             AudioPatchFeature.BindRepair,
             $"repaired-interface-bind bitrate={bitrate} volume={volume:0.###} spatialize={spatialize}",
             user,
-            source as IWorldElement,
+            source,
             controller?.Slot
         );
     }

--- a/TurboAudioStream/Patches/AudioStreamInterface_OutgoingTuning_Patch.cs
+++ b/TurboAudioStream/Patches/AudioStreamInterface_OutgoingTuning_Patch.cs
@@ -18,7 +18,12 @@ internal static class AudioStreamInterface_OutgoingTuning_Patch
     {
         try
         {
-            if (!AudioPatchPredicates.IsLocalSenderOpusStream(source, out OpusStream<StereoSample>? stream))
+            if (
+                !AudioPatchPredicates.IsLocalSenderOpusStream(
+                    source,
+                    out OpusStream<StereoSample>? stream
+                )
+            )
             {
                 return;
             }

--- a/TurboAudioStream/Patches/AudioStreamStereoSample_Read_ReceiverHeadroom_Patch.cs
+++ b/TurboAudioStream/Patches/AudioStreamStereoSample_Read_ReceiverHeadroom_Patch.cs
@@ -9,9 +9,20 @@ using HarmonyLib;
 
 namespace TurboAudioStream.Patches;
 
+[HarmonyPatch]
 internal static class AudioStreamStereoSample_Read_ReceiverHeadroom_Patch
 {
-    private static MethodBase TargetMethod()
+    private static readonly Action<AudioStream<StereoSample>, int> UpdateReadSampleCount =
+        AccessTools.MethodDelegate<Action<AudioStream<StereoSample>, int>>(
+            AccessTools.DeclaredMethod(typeof(AudioStream<StereoSample>), "UpdateReadSampleCount")
+                ?? throw new MissingMethodException(
+                    typeof(AudioStream<StereoSample>).FullName,
+                    "UpdateReadSampleCount"
+                )
+        );
+
+    [HarmonyTargetMethod]
+    internal static MethodInfo TargetMethod()
     {
         Type closedType = typeof(AudioStream<>).MakeGenericType(typeof(StereoSample));
         MethodInfo method = closedType
@@ -34,7 +45,14 @@ internal static class AudioStreamStereoSample_Read_ReceiverHeadroom_Patch
         ref int ____missedSamples
     )
     {
-        if (!AudioPatchPredicates.IsRemoteReceiverOpusStream(__instance, out OpusStream<StereoSample>? opusStream))
+        _ = simulator;
+
+        if (
+            !AudioPatchPredicates.IsRemoteReceiverOpusStream(
+                __instance,
+                out OpusStream<StereoSample>? opusStream
+            )
+        )
         {
             return true;
         }
@@ -42,7 +60,7 @@ internal static class AudioStreamStereoSample_Read_ReceiverHeadroom_Patch
         Engine? engine = __instance.Engine;
         if (__instance.IsDisposed || engine is null || __instance.User.IsAudioLocallyBlocked)
         {
-            buffer.Fill(default);
+            buffer.Clear();
             return false;
         }
 
@@ -63,10 +81,12 @@ internal static class AudioStreamStereoSample_Read_ReceiverHeadroom_Patch
         {
             if (___audioBuffer == null || ___audioBuffer.Length != effectiveTargetBufferSize)
             {
-                ___audioBuffer = new CircularAudioBuffer<StereoSample>(
-                    effectiveTargetBufferSize,
-                    ___audioBuffer
-                );
+                ___audioBuffer = ___audioBuffer is null
+                    ? new CircularAudioBuffer<StereoSample>(effectiveTargetBufferSize)
+                    : new CircularAudioBuffer<StereoSample>(
+                        effectiveTargetBufferSize,
+                        ___audioBuffer
+                    );
             }
 
             double dspTime = engine.AudioSystem.DSPTime;
@@ -74,7 +94,6 @@ internal static class AudioStreamStereoSample_Read_ReceiverHeadroom_Patch
                 sampleRate * effectiveMinimumBufferDelay
             );
             bool isNewFrame = ____lastAudioTime != dspTime;
-            double elapsedSeconds = ____lastAudioTime >= 0.0 ? dspTime - ____lastAudioTime : -1.0;
             ____lastAudioTime = dspTime;
 
             if (isNewFrame)
@@ -96,9 +115,9 @@ internal static class AudioStreamStereoSample_Read_ReceiverHeadroom_Patch
 
             if (____activeReading || hasEnoughBufferedSamples)
             {
-                __instance.UpdateReadSampleCount(buffer.Length);
+                UpdateReadSampleCount(__instance, buffer.Length);
                 int readSamples = ___audioBuffer.Read(buffer, ref globalPosition);
-                buffer.Slice(readSamples).Fill(default);
+                buffer[readSamples..].Clear();
                 ____missedSamples += buffer.Length - readSamples;
                 ____lastReadSamples = readSamples;
 
@@ -109,7 +128,7 @@ internal static class AudioStreamStereoSample_Read_ReceiverHeadroom_Patch
             }
             else
             {
-                buffer.Fill(default);
+                buffer.Clear();
             }
 
             if (!hasEnoughBufferedSamples)

--- a/TurboAudioStream/Patches/SessionIncomingMessageManager_ProcessStreamMessage_DropLog_Patch.cs
+++ b/TurboAudioStream/Patches/SessionIncomingMessageManager_ProcessStreamMessage_DropLog_Patch.cs
@@ -1,17 +1,27 @@
+using System;
 using System.Reflection;
 using FrooxEngine;
 using HarmonyLib;
 
 namespace TurboAudioStream.Patches;
 
+[HarmonyPatch]
 internal static class SessionIncomingMessageManager_ProcessStreamMessage_DropLog_Patch
 {
-    private static MethodBase TargetMethod() =>
-        AccessTools.Method(typeof(SessionIncomingMessageManager), "ProcessStreamMessage")!;
+    [HarmonyTargetMethod]
+    internal static MethodInfo TargetMethod() =>
+        AccessTools.DeclaredMethod(typeof(SessionIncomingMessageManager), "ProcessStreamMessage")
+        ?? throw new MissingMethodException(
+            typeof(SessionIncomingMessageManager).FullName,
+            "ProcessStreamMessage"
+        );
 
     public static void Prefix(SessionIncomingMessageManager __instance, StreamMessage stream)
     {
-        if (stream.IsOutdated || __instance.World.InitState != FrooxEngine.World.InitializationState.Finished)
+        if (
+            stream.IsOutdated
+            || __instance.World.InitState != FrooxEngine.World.InitializationState.Finished
+        )
         {
             StreamDropLogHelper.LogAsyncDrop("world-not-ready-or-outdated", stream);
         }

--- a/TurboAudioStream/Patches/SyncController_ApplyStreams_DropLog_Patch.cs
+++ b/TurboAudioStream/Patches/SyncController_ApplyStreams_DropLog_Patch.cs
@@ -21,7 +21,10 @@ internal static class SyncController_ApplyStreams_DropLog_Patch
             return;
         }
 
-        if (message.StreamGroup == ushort.MaxValue || user.StreamConfigurationVersion != message.StreamStateVersion)
+        if (
+            message.StreamGroup == ushort.MaxValue
+            || user.StreamConfigurationVersion != message.StreamStateVersion
+        )
         {
             string reason =
                 user.StreamConfigurationVersion != message.StreamStateVersion

--- a/TurboAudioStream/Patches/SyncController_AsyncStreamDecodeAndDispose_DropLog_Patch.cs
+++ b/TurboAudioStream/Patches/SyncController_AsyncStreamDecodeAndDispose_DropLog_Patch.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using FrooxEngine;
 using HarmonyLib;
 
@@ -29,13 +29,9 @@ internal static class SyncController_AsyncStreamDecodeAndDispose_DropLog_Patch
 
         try
         {
-            IStream stream = user.GetStream(streamId);
-            if (stream is null)
-            {
-                StreamDropLogHelper.LogAsyncDrop("missing-user-or-stream", message, user);
-            }
+            _ = user.GetStream(streamId);
         }
-        catch
+        catch (KeyNotFoundException)
         {
             StreamDropLogHelper.LogAsyncDrop("missing-user-or-stream", message, user);
         }

--- a/TurboAudioStream/StreamDropLogHelper.cs
+++ b/TurboAudioStream/StreamDropLogHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Elements.Core;
 using FrooxEngine;
 
@@ -23,6 +24,11 @@ internal static class StreamDropLogHelper
         );
     }
 
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Drop-log parsing must fail open so malformed async stream payloads do not break stream processing."
+    )]
     public static bool TryReadAsyncStreamId(StreamMessage message, out ulong streamId)
     {
         streamId = 0;
@@ -34,15 +40,7 @@ internal static class StreamDropLogHelper
             streamId = reader.Read7BitEncoded();
             return true;
         }
-        catch (ArgumentException)
-        {
-            return false;
-        }
-        catch (InvalidOperationException)
-        {
-            return false;
-        }
-        catch (System.IO.EndOfStreamException)
+        catch (Exception)
         {
             return false;
         }

--- a/TurboAudioStream/StreamDropLogHelper.cs
+++ b/TurboAudioStream/StreamDropLogHelper.cs
@@ -29,12 +29,20 @@ internal static class StreamDropLogHelper
 
         try
         {
-            BitReaderStream stream = new(message.GetData());
-            BitBinaryReaderX reader = new(stream);
+            using BitReaderStream stream = new(message.GetData());
+            using BitBinaryReaderX reader = new(stream);
             streamId = reader.Read7BitEncoded();
             return true;
         }
-        catch
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (System.IO.EndOfStreamException)
         {
             return false;
         }

--- a/TurboAudioStream/TurboAudioStreamMod.cs
+++ b/TurboAudioStream/TurboAudioStreamMod.cs
@@ -24,21 +24,20 @@ public sealed class TurboAudioStreamMod : ResoniteMod
 
     /// <inheritdoc />
     public override string Author =>
-        Assembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company
-        ?? string.Empty;
+        Assembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company ?? string.Empty;
 
     /// <inheritdoc />
     public override string Version =>
         Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-        ?? Assembly.GetName().Version?.ToString()
-        ?? "0.0.0";
+        ?? Assembly.GetName().Version?.ToString() ?? "0.0.0";
 
     /// <inheritdoc />
     public override string Link =>
         Assembly
             .GetCustomAttributes<AssemblyMetadataAttribute>()
             .FirstOrDefault(meta => meta.Key == "RepositoryUrl")
-            ?.Value ?? string.Empty;
+            ?.Value
+        ?? string.Empty;
 
     private static ModConfiguration? configuration;
 
@@ -164,7 +163,9 @@ public sealed class TurboAudioStreamMod : ResoniteMod
         TurboAudioStreamConfig.BufferSize = config.GetValue(BufferSizeKey);
         TurboAudioStreamConfig.ApplicationType = config.GetValue(OpusApplicationTypeKey);
         TurboAudioStreamConfig.EncoderDelay = config.GetValue(EncoderDelayKey);
-        TurboAudioStreamConfig.EnableOutgoingTuningPatch = config.GetValue(EnableOutgoingTuningPatchKey);
+        TurboAudioStreamConfig.EnableOutgoingTuningPatch = config.GetValue(
+            EnableOutgoingTuningPatchKey
+        );
         TurboAudioStreamConfig.EnableBindRepairPatch = config.GetValue(EnableBindRepairPatchKey);
         TurboAudioStreamConfig.EnableAsyncFreshnessGuardPatch = config.GetValue(
             EnableAsyncFreshnessGuardPatchKey
@@ -178,11 +179,15 @@ public sealed class TurboAudioStreamMod : ResoniteMod
         TurboAudioStreamConfig.EnablePatchTriggerLogging = config.GetValue(
             EnablePatchTriggerLoggingKey
         );
-        TurboAudioStreamConfig.PatchLogCooldownSeconds = config.GetValue(PatchLogCooldownSecondsKey);
+        TurboAudioStreamConfig.PatchLogCooldownSeconds = config.GetValue(
+            PatchLogCooldownSecondsKey
+        );
         TurboAudioStreamConfig.ReceiverMinimumBufferDelayFloor = config.GetValue(
             ReceiverMinimumBufferDelayFloorKey
         );
-        TurboAudioStreamConfig.ReceiverBufferSizeFloor = config.GetValue(ReceiverBufferSizeFloorKey);
+        TurboAudioStreamConfig.ReceiverBufferSizeFloor = config.GetValue(
+            ReceiverBufferSizeFloorKey
+        );
         AudioPatchManager.Synchronize();
     }
 


### PR DESCRIPTION
## Summary
- add a patch manager that enables and disables Harmony patches per feature
- add trigger logging for actual patch interventions with cooldown-based deduplication
- implement outgoing tuning, bind repair, async freshness guard, stream drop logging, and receiver headroom patches

## Verification
- dotnet build TurboAudioStream\\TurboAudioStream.csproj
- csharpier check .

## Notes
- This PR is stacked on top of #3 because the build and CI changes there are required for the current Resonite/.NET 10 environment.